### PR TITLE
DoS attack is possible using simple <!--> comment, this pull-request fixes it.

### DIFF
--- a/CommonMark/common.py
+++ b/CommonMark/common.py
@@ -26,7 +26,9 @@ OPENTAG = "<" + TAGNAME + ATTRIBUTE + "*" + "\\s*/?>"
 CLOSETAG = "</" + TAGNAME + "\\s*[>]"
 OPENBLOCKTAG = "<" + BLOCKTAGNAME + ATTRIBUTE + "*" + "\\s*/?>"
 CLOSEBLOCKTAG = "</" + BLOCKTAGNAME + "\\s*[>]"
-HTMLCOMMENT = "<!--([^-]+|[-][^-]+)*-->"
+# HTML comments are more complex than something between <!-- and -->
+# http://www.w3.org/TR/html5/syntax.html#comments
+HTMLCOMMENT = "<!--(?!>|->)(?:[^-]|-(?!-))*?-->"
 PROCESSINGINSTRUCTION = "[<][?].*?[?][>]"
 DECLARATION = "<![A-Z]+" + "\\s+[^>]*>"
 CDATA = "<!\\[CDATA\\[([^\\]]+|\\][^\\]]|\\]\\][^>])*\\]\\]>"

--- a/spec.txt
+++ b/spec.txt
@@ -5239,6 +5239,24 @@ Illegal attributes in closing tag:
 Comments:
 
 .
+empty comment <!---->
+.
+<p>empty comment <!----></p>
+.
+
+.
+text must not start with a single > <!-->-->
+.
+<p>text must not start with a single &gt; &lt;!--&gt;--&gt;</p>
+.
+
+.
+nor start with a -> <!--->-->
+.
+<p>nor start with a -&gt; &lt;!---&gt;--&gt;</p>
+.
+
+.
 foo <!-- this is a
 comment - with hyphen -->
 .
@@ -5251,6 +5269,7 @@ foo <!-- not a comment -- two hyphens -->
 .
 <p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
 .
+
 
 Processing instructions:
 


### PR DESCRIPTION
To check if DoS attack is possible against PyCommonMark version you use, create file with content:

```
s <!--> 1234567890123
[a link]()
 ```

and run `time bin/cmark.py minimal.md`. If it takes about 10 seconds
to parse, then your version os CommonMark is vulnerable.